### PR TITLE
ENTESB-17657 Fix KafkaIT native test

### DIFF
--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -23,7 +23,12 @@ timer.period = 10000
 timer.delay = 10000
 
 # Use Quarkus Kafka Dev Services local container in test mode
-%test.camel.component.kafka.brokers=${kafka.bootstrap.servers}
+# Remove this property when camel-quarkus includes the fixes of Improve Kafka integration with Quarkus dev services
+# https://github.com/apache/camel-quarkus/issues/3121
+# https://github.com/apache/camel-quarkus/issues/3157
+# https://github.com/apache/camel-quarkus/issues/3206
+#
+camel.component.kafka.brokers=${kafka.bootstrap.servers}
 
 # uncomment to set Kafka credentials with SASL Plain
 #camel.component.kafka.brokers=<YOUR_KAFKA_BROKERS_URL>


### PR DESCRIPTION
Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.