### PR TITLE
Kafka example : SSL is needed for Strimzi oauth in native mode

### DIFF
--- a/kafka/src/main/resources/application.properties
+++ b/kafka/src/main/resources/application.properties
@@ -32,6 +32,7 @@ timer.delay = 10000
 #camel.component.kafka.sasl-jaas-config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<YOUR_KAFKA_SASL_CLIENT_ID>" password="<YOUR_KAFKA_SASL_CLIENT_SECRET>";
 
 # uncomment to set Kafka instance with SASL Oauth Bearer
+#quarkus.ssl.native=true
 #camel.component.kafka.brokers = <YOUR_KAFKA_BROKERS_URL>
 #camel.component.kafka.security-protocol = SASL_SSL
 #camel.component.kafka.sasl-mechanism = OAUTHBEARER


### PR DESCRIPTION
Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.