### PR TITLE
CEQ-5178 file-bindy-ftp example does not work on Openshift

### DIFF
--- a/file-bindy-ftp/src/main/kubernetes/openshift.yml
+++ b/file-bindy-ftp/src/main/kubernetes/openshift.yml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: openssh-server
           # Use a simple SFTP server implementation based on Apache Mina SSHD. Purely for testing only, NOT for production use
-          image: quay.io/jamesnetherton/sftp-server:0.1.0
+          image: quay.io/jamesnetherton/sftp-server:0.2.0
           ports:
             - containerPort: 2222
           env:


### PR DESCRIPTION
Cherry-picked  5a69c73beb776e2d92b845aff175c7c7c7f16327 from https://github.com/jboss-fuse/camel-quarkus-examples/pull/22

Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.