### PR TITLE
Upgrade sftp-server container image to 0.5.0

### DIFF
--- a/file-bindy-ftp/src/main/kubernetes/openshift.yml
+++ b/file-bindy-ftp/src/main/kubernetes/openshift.yml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: openssh-server
           # Use a simple SFTP server implementation based on Apache Mina SSHD. Purely for testing only, NOT for production use
-          image: quay.io/jamesnetherton/sftp-server:0.4.0
+          image: quay.io/jamesnetherton/sftp-server:0.5.0
           ports:
             - containerPort: 2222
           env:

--- a/file-bindy-ftp/src/test/java/org/apache/camel/example/FtpTestResource.java
+++ b/file-bindy-ftp/src/test/java/org/apache/camel/example/FtpTestResource.java
@@ -30,7 +30,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public class FtpTestResource implements QuarkusTestResourceLifecycleManager {
 
     private static final int FTP_PORT = 2222;
-    private static final String SSH_IMAGE = "quay.io/jamesnetherton/sftp-server:0.4.0";
+    private static final String SSH_IMAGE = "quay.io/jamesnetherton/sftp-server:0.5.0";
 
     private GenericContainer container;
 


### PR DESCRIPTION
Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.