### PR TITLE
Set proper parent for sage examples

### DIFF
--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -29,7 +29,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version>
 

--- a/saga/saga-app/pom.xml
+++ b/saga/saga-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-app</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/saga/saga-flight-service/pom.xml
+++ b/saga/saga-flight-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-flight</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/saga/saga-payment-service/pom.xml
+++ b/saga/saga-payment-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-	<version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-payment</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/saga/saga-train-service/pom.xml
+++ b/saga/saga-train-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-train</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>


### PR DESCRIPTION
Fixed parent dependencies for saga sub-modules.

Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.