### PR TITLE
Upgraded quarkus.platform.version to 3.15.2.redhat-00002

### DIFF
--- a/artemis-elasticsearch/pom.xml
+++ b/artemis-elasticsearch/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Artemis ElasticSearch</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/artemis-elasticsearch/src/test/java/org/acme/resource/CustomPahoTestResource.java
+++ b/artemis-elasticsearch/src/test/java/org/acme/resource/CustomPahoTestResource.java
@@ -27,7 +27,7 @@ public class CustomPahoTestResource implements QuarkusTestResourceLifecycleManag
     private static final String IMAGE_NAME = "quay.io/artemiscloud/activemq-artemis-broker:1.0.26";
     private static final String AMQ_USER = "admin";
     private static final String AMQ_PASSWORD = "admin";
-    private static final String AMQ_JOLOKIA = "--relax-jolokia";
+    private static final String AMQ_EXTRA_ARGS = "--relax-jolokia --no-autotune --mapped --no-fsync --java-options=-Dbrokerconfig.maxDiskUsage=-1";
     private GenericContainer<?> container;
 
     @Override
@@ -36,8 +36,8 @@ public class CustomPahoTestResource implements QuarkusTestResourceLifecycleManag
                 .withExposedPorts(61616, 8161, 1883)
                 .withEnv("AMQ_USER", AMQ_USER)
                 .withEnv("AMQ_PASSWORD", AMQ_PASSWORD)
-                .withEnv("AMQ_EXTRA_ARGS", AMQ_JOLOKIA);
-        //.withPrivilegedMode(true);
+                .withEnv("AMQ_EXTRA_ARGS", AMQ_EXTRA_ARGS)
+                .withLogConsumer(outputFrame -> System.out.print(outputFrame.getUtf8String()));
 
         container.start();
 

--- a/cluster-leader-election/pom.xml
+++ b/cluster-leader-election/pom.xml
@@ -29,7 +29,7 @@
     <description>Camel Quarkus Example :: Cluster leader election</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/cxf-soap/pom.xml
+++ b/cxf-soap/pom.xml
@@ -29,7 +29,7 @@
     <description>Camel Quarkus Example :: CXF SOAP</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/file-bindy-ftp/pom.xml
+++ b/file-bindy-ftp/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File Bindy FTP</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/file-split-log-xml/pom.xml
+++ b/file-split-log-xml/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: File To Log XML DSL</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Health Check</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/http-log/pom.xml
+++ b/http-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: HTTP to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/jdbc-datasource/pom.xml
+++ b/jdbc-datasource/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: Jdbc - DatataSource - Log</name>
     <description>Camel Quarkus Example :: Connect to Database using Datasource</description>
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/jms-jpa/pom.xml
+++ b/jms-jpa/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: JMS JPA</name>
     <description>Camel Quarkus Example :: JMS JPA</description>
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version>
 

--- a/jpa-idempotent-repository/pom.xml
+++ b/jpa-idempotent-repository/pom.xml
@@ -30,7 +30,7 @@
     <description>Camel Quarkus Example :: JPA Idempotent Repository</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/jta-jpa/pom.xml
+++ b/jta-jpa/pom.xml
@@ -25,7 +25,7 @@
     <name>Camel Quarkus :: Examples :: JTA JPA</name>
     <description>Camel Quarkus Example :: JTA JPA</description>
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kafka</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Kamelet Chuck Norris</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/message-bridge/pom.xml
+++ b/message-bridge/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Configure XA Transactions and connection pooling</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/message-bridge/src/main/resources/application.properties
+++ b/message-bridge/src/main/resources/application.properties
@@ -46,5 +46,5 @@ dummy.resource.directory=target/DummyXAResource
 %kubernetes.dummy.resource.directory=/storage/DummyXAResource
 quarkus.transaction-manager.enable-recovery=true
 
-# do not block artemis if there is les then 90% of free space
+# do not block artemis if there is less than 10% of free disk space
 quarkus.artemis.devservices.extra-args=--no-autotune --mapped --no-fsync --java-options=-Dbrokerconfig.maxDiskUsage=-1

--- a/message-bridge/src/main/resources/application.properties
+++ b/message-bridge/src/main/resources/application.properties
@@ -45,3 +45,6 @@ dummy.resource.directory=target/DummyXAResource
 %openshift.dummy.resource.directory=/storage/DummyXAResource
 %kubernetes.dummy.resource.directory=/storage/DummyXAResource
 quarkus.transaction-manager.enable-recovery=true
+
+# do not block artemis if there is les then 90% of free space
+quarkus.artemis.devservices.extra-args=--no-autotune --mapped --no-fsync --java-options=-Dbrokerconfig.maxDiskUsage=-1

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: openapi-contract-first</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/platform-http-security-keycloak/pom.xml
+++ b/platform-http-security-keycloak/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Platform HTTP Security Keycloak</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/rest-json/pom.xml
+++ b/rest-json/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Rest Json</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -29,7 +29,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
         <quarkiverse-artemis.version>3.4.2</quarkiverse-artemis.version>
 

--- a/saga/saga-app/pom.xml
+++ b/saga/saga-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-app</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/saga/saga-flight-service/pom.xml
+++ b/saga/saga-flight-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-flight</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/saga/saga-payment-service/pom.xml
+++ b/saga/saga-payment-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-	<version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-payment</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/saga/saga-train-service/pom.xml
+++ b/saga/saga-train-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>camel-quarkus-examples-saga</artifactId>
         <groupId>org.apache.camel.quarkus.examples</groupId>
-        <version>3.15.0</version>
+        <version>3.15.0.redhat-00001</version>
     </parent>
 
     <artifactId>camel-quarkus-example-saga-train</artifactId>
@@ -35,7 +35,7 @@
     <properties>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
         <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>

--- a/timer-log-main/pom.xml
+++ b/timer-log-main/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log Main</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/timer-log/pom.xml
+++ b/timer-log/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Timer to Log</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>

--- a/vertx-websocket-chat/pom.xml
+++ b/vertx-websocket-chat/pom.xml
@@ -28,7 +28,7 @@
     <description>Camel Quarkus Example :: Implementing Websocket</description>
 
     <properties>
-        <quarkus.platform.version>3.15.1.SP1-temporary-redhat-00001</quarkus.platform.version>
+        <quarkus.platform.version>3.15.2.redhat-00002</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>


### PR DESCRIPTION
- Upgraded quarkus.platform.version to 3.15.2.redhat-00002
- Fixed parent issues for Sage example.
- Message-bridge - removed restriction to have at least 10%  of free space to avoid artemis blocking.

Note that the `master` branch points at the latest stable Camel Quarkus release.
Pull requests should be generally send against the `camel-quarkus-master` branch pointing at the current Camel Quarkus SNAPSHOT.